### PR TITLE
Add RKT_OPTS for docker logging

### DIFF
--- a/modules/worker/cloud-config.tf
+++ b/modules/worker/cloud-config.tf
@@ -117,7 +117,10 @@ coreos:
         Environment="KUBELET_VERSION=${ coreos-hyperkube-tag }"
         Environment="RKT_OPTS=\
         --volume=resolv,kind=host,source=/etc/resolv.conf \
-        --mount volume=resolv,target=/etc/resolv.conf"
+        --mount volume=resolv,target=/etc/resolv.conf \
+        --volume var-log,kind=host,source=/var/log \
+        --mount volume=var-log,target=/var/log"
+        ExecStartPre=/usr/bin/mkdir -p /var/log/containers
         ExecStart=/usr/lib/coreos/kubelet-wrapper \
           --allow-privileged=true \
           --api-servers=http://master.${ internal-tld }:8080 \


### PR DESCRIPTION
Without these, there will be no logs under /var/log/containers and fluentd will not send any logs to elasticsearch.  

 Based on https://github.com/kubernetes/kubernetes/issues/27720  and   https://coreos.com/kubernetes/docs/latest/kubelet-wrapper.html#use-the-cluster-logging-add-on
